### PR TITLE
Add security schemes

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -16,7 +16,9 @@ servers:
   - url: https://enterprise.lemmy.ml/api/v3
   - url: https://ds9.lemmy.ml/api/v3
   - url: https://voyager.lemmy.ml/api/v3
-security: []
+security:
+  - bearerAuth: []
+  - cookieAuth: []
 paths:
   /site:
     get:
@@ -1501,14 +1503,13 @@ paths:
     get:
       tags:
         - User
-      operationId: getUserExport
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/GetUserExportResponse'
       summary: '[MANUAL] Export your user data.'
   /user/import:
     post:
@@ -1518,13 +1519,21 @@ paths:
         content:
           application/json:
             schema:
-              type: string
-      operationId: getUserImport
+              $ref: '#/components/schemas/GetUserImportResponse'
       responses:
         '200':
           description: OK
       summary: '[MANUAL] Import your user data.'
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: auth
   schemas:
     errorResponseRegistration:
       properties:
@@ -1550,6 +1559,10 @@ components:
             - registration_application_is_pending
             - missing_totp_token
             - incorrect_totp_token
+    GetUserExportResponse:
+      type: string
+    GetUserImportResponse:
+      type: string
     SiteId:
       title: SiteId
       type: integer

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -18,6 +18,15 @@ servers:
   - url: https://voyager.lemmy.ml/api/v3
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: auth
   schemas:
     errorResponseRegistration:
       properties:
@@ -43,8 +52,15 @@ components:
             - registration_application_is_pending
             - missing_totp_token
             - incorrect_totp_token
+      # TODO: add the schema, is not exported currently
+    GetUserExportResponse:
+      type: string
+    GetUserImportResponse:
+      type: string
 
-security: []
+security:
+  - bearerAuth: [ ]
+  - cookieAuth: [ ]
 
 paths:
   /site:
@@ -1546,15 +1562,13 @@ paths:
     get:
       tags:
         - User
-      operationId: getUserExport
       responses:
         200:
           description: OK
           content:
             application/json:
-              # TODO: add the schema, is not exported currently
               schema:
-                type: string
+                $ref: '#/components/schemas/GetUserExportResponse'
       summary: '[MANUAL] Export your user data.'
   /user/import:
     post:
@@ -1564,8 +1578,7 @@ paths:
         content:
           application/json:
             schema:
-              type: string
-      operationId: getUserImport
+              $ref: '#/components/schemas/GetUserImportResponse'
       responses:
         200:
           description: OK


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding security schemes for bearer authentication and cookie authentication. It also adds schemas for GetUserExportResponse and GetUserImportResponse. 

### Detailed summary
- Added `securitySchemes` for `bearerAuth` and `cookieAuth`
- Added schemas for `GetUserExportResponse` and `GetUserImportResponse`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->