### PR TITLE
Update naming of import/export_settings

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1484,7 +1484,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetUserExportSettingsResponse'
+                $ref: '#/components/schemas/ExportUserSettingsResponse'
       summary: "Export a backup of your user settings, including your saved content,\r followed communities, and blocks."
   /user/import_settings:
     post:
@@ -1494,7 +1494,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GetUserImportSettings'
+              $ref: '#/components/schemas/ImportUserSettings'
       responses:
         '200':
           description: OK
@@ -1570,9 +1570,9 @@ components:
             - registration_application_is_pending
             - missing_totp_token
             - incorrect_totp_token
-    GetUserExportSettingsResponse:
+    ExportUserSettingsResponse:
       type: string
-    GetUserImportSettings:
+    ImportUserSettings:
       type: string
     SiteId:
       title: SiteId

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -53,9 +53,9 @@ components:
             - missing_totp_token
             - incorrect_totp_token
       # TODO: add the schema, is not exported currently
-    GetUserExportSettingsResponse:
+    ExportUserSettingsResponse:
       type: string
-    GetUserImportSettings:
+    ImportUserSettings:
       type: string
 
 security:
@@ -1543,7 +1543,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetUserExportSettingsResponse'
+                $ref: '#/components/schemas/ExportUserSettingsResponse'
       summary: "Export a backup of your user settings, including your saved content,\r
         followed communities, and blocks."
   /user/import_settings:
@@ -1554,7 +1554,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/GetUserImportSettings'
+              $ref: '#/components/schemas/ImportUserSettings'
       responses:
         200:
           description: OK


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on renaming and updating the schema names for exporting and importing user settings. 

### Detailed summary
- Renamed `GetUserExportSettingsResponse` to `ExportUserSettingsResponse`
- Renamed `GetUserImportSettings` to `ImportUserSettings`
- Updated references to the renamed schemas in the code

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->