### PR TITLE
Update spec to v0.19.3 release

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1553,6 +1553,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListPostLikesResponse'
+      summary: '[MANUAL] TODO until fix'
   /comment/like/list:
     get:
       tags:
@@ -1569,6 +1570,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListCommentLikesResponse'
+      summary: '[MANUAL] TODO until fix'
 components:
   securitySchemes:
     bearerAuth:

--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Unofficial Lemmy OpenAPI Documentation
-  version: v0.19.0
+  version: v0.19.3
   license:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html#license-text
@@ -1537,6 +1537,38 @@ paths:
         '200':
           description: OK
       summary: '[MANUAL] Logout your user, which clears the cookie and invalidates the auth token'
+  /post/like/list:
+    get:
+      tags:
+        - Admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListPostLikes'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPostLikesResponse'
+  /comment/like/list:
+    get:
+      tags:
+        - Admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListCommentLikes'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListCommentLikesResponse'
 components:
   securitySchemes:
     bearerAuth:
@@ -3944,6 +3976,9 @@ components:
         published:
           title: PostAggregates.published
           type: string
+        newest_comment_time:
+          title: PostAggregates.newest_comment_time
+          type: string
       required:
         - post_id
         - comments
@@ -3951,6 +3986,7 @@ components:
         - upvotes
         - downvotes
         - published
+        - newest_comment_time
       additionalProperties: false
       title: PostAggregates
       type: object
@@ -4040,6 +4076,9 @@ components:
         users_active_half_year:
           title: CommunityAggregates.users_active_half_year
           type: integer
+        subscribers_local:
+          title: CommunityAggregates.subscribers_local
+          type: integer
       required:
         - community_id
         - subscribers
@@ -4050,6 +4089,7 @@ components:
         - users_active_week
         - users_active_month
         - users_active_half_year
+        - subscribers_local
       additionalProperties: false
       title: CommunityAggregates
       type: object
@@ -4200,6 +4240,9 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: EditCommunity.discussion_languages
           type: array
+        local_only:
+          title: EditCommunity.local_only
+          type: boolean
       required:
         - community_id
       additionalProperties: false
@@ -4249,6 +4292,9 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: CreateCommunity.discussion_languages
           type: array
+        local_only:
+          title: CreateCommunity.local_only
+          type: boolean
       required:
         - name
         - title
@@ -6717,4 +6763,74 @@ components:
         - published
       additionalProperties: false
       title: LoginToken
+      type: object
+    ListPostLikes:
+      properties:
+        post_id:
+          $ref: '#/components/schemas/PostId'
+          title: ListPostLikes.post_id
+        page:
+          title: ListPostLikes.page
+          type: integer
+        limit:
+          title: ListPostLikes.limit
+          type: integer
+      required:
+        - post_id
+      additionalProperties: false
+      title: ListPostLikes
+      type: object
+    VoteView:
+      properties:
+        creator:
+          $ref: '#/components/schemas/Person'
+          title: VoteView.creator
+        score:
+          title: VoteView.score
+          type: integer
+      required:
+        - creator
+        - score
+      additionalProperties: false
+      title: VoteView
+      type: object
+    ListPostLikesResponse:
+      properties:
+        post_likes:
+          items:
+            $ref: '#/components/schemas/VoteView'
+          title: ListPostLikesResponse.post_likes
+          type: array
+      required:
+        - post_likes
+      additionalProperties: false
+      title: ListPostLikesResponse
+      type: object
+    ListCommentLikes:
+      properties:
+        comment_id:
+          $ref: '#/components/schemas/CommentId'
+          title: ListCommentLikes.comment_id
+        page:
+          title: ListCommentLikes.page
+          type: integer
+        limit:
+          title: ListCommentLikes.limit
+          type: integer
+      required:
+        - comment_id
+      additionalProperties: false
+      title: ListCommentLikes
+      type: object
+    ListCommentLikesResponse:
+      properties:
+        comment_likes:
+          items:
+            $ref: '#/components/schemas/VoteView'
+          title: ListCommentLikesResponse.comment_likes
+          type: array
+      required:
+        - comment_likes
+      additionalProperties: false
+      title: ListCommentLikesResponse
       type: object

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1614,6 +1614,7 @@ paths:
             application/json:
               schema:
                 $ref: 'components.yaml#/components/schemas/ListPostLikesResponse'
+      summary: '[MANUAL] TODO until fix'
   /comment/like/list:
     get:
       tags:
@@ -1630,3 +1631,4 @@ paths:
             application/json:
               schema:
                 $ref: 'components.yaml#/components/schemas/ListCommentLikesResponse'
+      summary: '[MANUAL] TODO until fix'

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: Unofficial Lemmy OpenAPI Documentation
-  version: v0.19.0
+  version: v0.19.3
   license:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html#license-text
@@ -1598,3 +1598,35 @@ paths:
           description: OK
       summary: '[MANUAL] Logout your user, which clears the cookie and invalidates the
         auth token'
+  /post/like/list:
+    get:
+      tags:
+        - Admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'components.yaml#/components/schemas/ListPostLikes'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yaml#/components/schemas/ListPostLikesResponse'
+  /comment/like/list:
+    get:
+      tags:
+        - Admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'components.yaml#/components/schemas/ListCommentLikes'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: 'components.yaml#/components/schemas/ListCommentLikesResponse'

--- a/partials/auto_gen_types.ts
+++ b/partials/auto_gen_types.ts
@@ -333,6 +333,7 @@ export interface CommunityAggregates {
   users_active_week: bigint;
   users_active_month: bigint;
   users_active_half_year: bigint;
+  subscribers_local: bigint;
 }
 
 
@@ -400,6 +401,7 @@ export interface CreateCommunity {
   nsfw?: boolean;
   posting_restricted_to_mods?: boolean;
   discussion_languages?: Array<LanguageId>;
+  local_only?: boolean;
 }
 
 
@@ -579,6 +581,7 @@ export interface EditCommunity {
   nsfw?: boolean;
   posting_restricted_to_mods?: boolean;
   discussion_languages?: Array<LanguageId>;
+  local_only?: boolean;
 }
 
 
@@ -1090,13 +1093,25 @@ export type LemmyErrorType =
   | { error: "couldnt_send_webmention" }
   | { error: "contradicting_filters" }
   | { error: "instance_block_already_exists" }
-  | { error: "auth_cookie_insecure" }
   | { error: "too_many_items" }
   | { error: "community_has_no_followers" }
   | { error: "ban_expiration_in_past" }
   | { error: "invalid_unix_time" }
   | { error: "invalid_bot_action" }
+  | { error: "cant_block_local_instance" }
   | { error: "unknown"; message: string };
+
+
+export interface ListCommentLikes {
+  comment_id: CommentId;
+  page?: bigint;
+  limit?: bigint;
+}
+
+
+export interface ListCommentLikesResponse {
+  comment_likes: Array<VoteView>;
+}
 
 
 export interface ListCommentReports {
@@ -1127,6 +1142,18 @@ export interface ListCommunitiesResponse {
 
 
 export type ListingType = "All" | "Local" | "Subscribed" | "ModeratorView";
+
+
+export interface ListPostLikes {
+  post_id: PostId;
+  page?: bigint;
+  limit?: bigint;
+}
+
+
+export interface ListPostLikesResponse {
+  post_likes: Array<VoteView>;
+}
 
 
 export interface ListPostReports {
@@ -1674,6 +1701,7 @@ export interface PostAggregates {
   upvotes: bigint;
   downvotes: bigint;
   published: string;
+  newest_comment_time: string;
 }
 
 
@@ -2120,4 +2148,10 @@ export interface UpdateTotpResponse {
 
 export interface VerifyEmail {
   token: string;
+}
+
+
+export interface VoteView {
+  creator: Person;
+  score: bigint;
 }

--- a/partials/components.yaml
+++ b/partials/components.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Unofficial Lemmy Documentation
-  version: v0.19.0
+  version: v0.19.3
   x-id: partials/components.yaml
   x-comment: >-
     Generated from partials/auto_gen_types.ts by core-types-json-schema
@@ -904,6 +904,9 @@ components:
         users_active_half_year:
           title: CommunityAggregates.users_active_half_year
           type: integer
+        subscribers_local:
+          title: CommunityAggregates.subscribers_local
+          type: integer
       required:
         - community_id
         - subscribers
@@ -914,6 +917,7 @@ components:
         - users_active_week
         - users_active_month
         - users_active_half_year
+        - subscribers_local
       additionalProperties: false
       title: CommunityAggregates
       type: object
@@ -1076,6 +1080,9 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: CreateCommunity.discussion_languages
           type: array
+        local_only:
+          title: CreateCommunity.local_only
+          type: boolean
       required:
         - name
         - title
@@ -1545,6 +1552,9 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: EditCommunity.discussion_languages
           type: array
+        local_only:
+          title: EditCommunity.local_only
+          type: boolean
       required:
         - community_id
       additionalProperties: false
@@ -4142,17 +4152,6 @@ components:
             error:
               title: LemmyErrorType.error
               enum:
-                - auth_cookie_insecure
-              type: string
-          required:
-            - error
-          additionalProperties: false
-          title: LemmyErrorType
-          type: object
-        - properties:
-            error:
-              title: LemmyErrorType.error
-              enum:
                 - too_many_items
               type: string
           required:
@@ -4208,6 +4207,17 @@ components:
             error:
               title: LemmyErrorType.error
               enum:
+                - cant_block_local_instance
+              type: string
+          required:
+            - error
+          additionalProperties: false
+          title: LemmyErrorType
+          type: object
+        - properties:
+            error:
+              title: LemmyErrorType.error
+              enum:
                 - unknown
               type: string
             message:
@@ -4220,6 +4230,34 @@ components:
           title: LemmyErrorType
           type: object
       title: LemmyErrorType
+    ListCommentLikes:
+      properties:
+        comment_id:
+          $ref: '#/components/schemas/CommentId'
+          title: ListCommentLikes.comment_id
+        page:
+          title: ListCommentLikes.page
+          type: integer
+        limit:
+          title: ListCommentLikes.limit
+          type: integer
+      required:
+        - comment_id
+      additionalProperties: false
+      title: ListCommentLikes
+      type: object
+    ListCommentLikesResponse:
+      properties:
+        comment_likes:
+          items:
+            $ref: '#/components/schemas/VoteView'
+          title: ListCommentLikesResponse.comment_likes
+          type: array
+      required:
+        - comment_likes
+      additionalProperties: false
+      title: ListCommentLikesResponse
+      type: object
     ListCommentReports:
       properties:
         page:
@@ -4289,6 +4327,34 @@ components:
         - ModeratorView
       title: ListingType
       type: string
+    ListPostLikes:
+      properties:
+        post_id:
+          $ref: '#/components/schemas/PostId'
+          title: ListPostLikes.post_id
+        page:
+          title: ListPostLikes.page
+          type: integer
+        limit:
+          title: ListPostLikes.limit
+          type: integer
+      required:
+        - post_id
+      additionalProperties: false
+      title: ListPostLikes
+      type: object
+    ListPostLikesResponse:
+      properties:
+        post_likes:
+          items:
+            $ref: '#/components/schemas/VoteView'
+          title: ListPostLikesResponse.post_likes
+          type: array
+      required:
+        - post_likes
+      additionalProperties: false
+      title: ListPostLikesResponse
+      type: object
     ListPostReports:
       properties:
         page:
@@ -5787,6 +5853,9 @@ components:
         published:
           title: PostAggregates.published
           type: string
+        newest_comment_time:
+          title: PostAggregates.newest_comment_time
+          type: string
       required:
         - post_id
         - comments
@@ -5794,6 +5863,7 @@ components:
         - upvotes
         - downvotes
         - published
+        - newest_comment_time
       additionalProperties: false
       title: PostAggregates
       type: object
@@ -6905,4 +6975,18 @@ components:
         - token
       additionalProperties: false
       title: VerifyEmail
+      type: object
+    VoteView:
+      properties:
+        creator:
+          $ref: '#/components/schemas/Person'
+          title: VoteView.creator
+        score:
+          title: VoteView.score
+          type: integer
+      required:
+        - creator
+        - score
+      additionalProperties: false
+      title: VoteView
       type: object

--- a/src/gen_components.ts
+++ b/src/gen_components.ts
@@ -9,7 +9,7 @@ const reader = getTypeScriptReaderV2({unsupported: "warn"});
 const writer = getOpenApiWriter({
         format: 'yaml',
         title: 'Unofficial Lemmy Documentation',
-        version: 'v0.19.0',
+        version: 'v0.19.3',
         schemaVersion: "3.0.3"
     },
 )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the Lemmy documentation and client version. 

### Detailed summary
- Updated Lemmy client version from v0.19.0 to v0.19.3
- Updated Lemmy documentation version from v0.19.0 to v0.19.3
- Added new API routes for listing post likes and comment likes
- Added new schemas for listing post likes and comment likes response
- Added new properties for local_only in CreateCommunity and EditCommunity interfaces
- Added new properties for subscribers_local in CommunityAggregates interface
- Added new properties for newest_comment_time in PostAggregates interface
- Added new schemas for ListPostLikes, ListPostLikesResponse, ListCommentLikes, ListCommentLikesResponse, and VoteView

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->