### PR TITLE
Add missing summary

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1553,7 +1553,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListPostLikesResponse'
-      summary: '[MANUAL] TODO until fix'
+      summary: List a posts's likes. Admin-only.
   /comment/like/list:
     get:
       tags:
@@ -1570,7 +1570,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListCommentLikesResponse'
-      summary: '[MANUAL] TODO until fix'
+      summary: List a comment's likes. Admin-only.
 components:
   securitySchemes:
     bearerAuth:

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1614,7 +1614,7 @@ paths:
             application/json:
               schema:
                 $ref: 'components.yaml#/components/schemas/ListPostLikesResponse'
-      summary: '[MANUAL] TODO until fix'
+      summary: 'List a posts''s likes. Admin-only.'
   /comment/like/list:
     get:
       tags:
@@ -1631,4 +1631,4 @@ paths:
             application/json:
               schema:
                 $ref: 'components.yaml#/components/schemas/ListCommentLikesResponse'
-      summary: '[MANUAL] TODO until fix'
+      summary: 'List a comment''s likes. Admin-only.'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the summary for listing likes on posts and comments to indicate that it is admin-only. 

### Detailed summary
- Updated the summary for listing a post's likes to indicate that it is admin-only.
- Updated the summary for listing a comment's likes to indicate that it is admin-only.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->