### PR TITLE
Fix response for approve application endpoint

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1327,7 +1327,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RegistrationApplicationView'
+                $ref: '#/components/schemas/RegistrationApplicationResponse'
       summary: Approve a registration application
   /admin/purge/person:
     post:
@@ -4078,9 +4078,6 @@ components:
         users_active_half_year:
           title: CommunityAggregates.users_active_half_year
           type: integer
-        subscribers_local:
-          title: CommunityAggregates.subscribers_local
-          type: integer
       required:
         - community_id
         - subscribers
@@ -4091,7 +4088,6 @@ components:
         - users_active_week
         - users_active_month
         - users_active_half_year
-        - subscribers_local
       additionalProperties: false
       title: CommunityAggregates
       type: object
@@ -4242,9 +4238,6 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: EditCommunity.discussion_languages
           type: array
-        local_only:
-          title: EditCommunity.local_only
-          type: boolean
       required:
         - community_id
       additionalProperties: false
@@ -4294,9 +4287,6 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: CreateCommunity.discussion_languages
           type: array
-        local_only:
-          title: CreateCommunity.local_only
-          type: boolean
       required:
         - name
         - title
@@ -5862,6 +5852,9 @@ components:
         person_view:
           $ref: '#/components/schemas/PersonView'
           title: GetPersonDetailsResponse.person_view
+        site:
+          $ref: '#/components/schemas/Site'
+          title: GetPersonDetailsResponse.site
         comments:
           items:
             $ref: '#/components/schemas/CommentView'
@@ -6559,6 +6552,16 @@ components:
         - approve
       additionalProperties: false
       title: ApproveRegistrationApplication
+      type: object
+    RegistrationApplicationResponse:
+      properties:
+        registration_application:
+          $ref: '#/components/schemas/RegistrationApplicationView'
+          title: RegistrationApplicationResponse.registration_application
+      required:
+        - registration_application
+      additionalProperties: false
+      title: RegistrationApplicationResponse
       type: object
     PurgePerson:
       properties:

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1382,7 +1382,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'components.yaml#/components/schemas/RegistrationApplicationView'
+                $ref: 'components.yaml#/components/schemas/RegistrationApplicationResponse'
       summary: Approve a registration application
   /admin/purge/person:
     post:

--- a/partials/auto_gen_types.ts
+++ b/partials/auto_gen_types.ts
@@ -333,7 +333,6 @@ export interface CommunityAggregates {
   users_active_week: bigint;
   users_active_month: bigint;
   users_active_half_year: bigint;
-  subscribers_local: bigint;
 }
 
 
@@ -401,7 +400,6 @@ export interface CreateCommunity {
   nsfw?: boolean;
   posting_restricted_to_mods?: boolean;
   discussion_languages?: Array<LanguageId>;
-  local_only?: boolean;
 }
 
 
@@ -581,7 +579,6 @@ export interface EditCommunity {
   nsfw?: boolean;
   posting_restricted_to_mods?: boolean;
   discussion_languages?: Array<LanguageId>;
-  local_only?: boolean;
 }
 
 
@@ -771,6 +768,7 @@ export interface GetPersonDetails {
 
 export interface GetPersonDetailsResponse {
   person_view: PersonView;
+  site?: Site;
   comments: Array<CommentView>;
   posts: Array<PostView>;
   moderates: Array<CommunityModeratorView>;

--- a/partials/components.yaml
+++ b/partials/components.yaml
@@ -904,9 +904,6 @@ components:
         users_active_half_year:
           title: CommunityAggregates.users_active_half_year
           type: integer
-        subscribers_local:
-          title: CommunityAggregates.subscribers_local
-          type: integer
       required:
         - community_id
         - subscribers
@@ -917,7 +914,6 @@ components:
         - users_active_week
         - users_active_month
         - users_active_half_year
-        - subscribers_local
       additionalProperties: false
       title: CommunityAggregates
       type: object
@@ -1080,9 +1076,6 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: CreateCommunity.discussion_languages
           type: array
-        local_only:
-          title: CreateCommunity.local_only
-          type: boolean
       required:
         - name
         - title
@@ -1552,9 +1545,6 @@ components:
             $ref: '#/components/schemas/LanguageId'
           title: EditCommunity.discussion_languages
           type: array
-        local_only:
-          title: EditCommunity.local_only
-          type: boolean
       required:
         - community_id
       additionalProperties: false
@@ -2091,6 +2081,9 @@ components:
         person_view:
           $ref: '#/components/schemas/PersonView'
           title: GetPersonDetailsResponse.person_view
+        site:
+          $ref: '#/components/schemas/Site'
+          title: GetPersonDetailsResponse.site
         comments:
           items:
             $ref: '#/components/schemas/CommentView'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Updated the `$ref` in `partials/api_routes.yaml` from `RegistrationApplicationView` to `RegistrationApplicationResponse`.
- Removed the `local_only` property from the `CreateCommunity` and `EditCommunity` interfaces in `partials/auto_gen_types.ts`.
- Added a new property `site` of type `Site` to the `GetPersonDetailsResponse` interface in `partials/auto_gen_types.ts`.
- Updated the title and type of the `users_active_half_year` property in `partials/components.yaml`.
- Removed the `subscribers_local` property from the `CommunityAggregates` schema in `partials/components.yaml`.
- Removed the `local_only` property from the `CreateCommunity` and `EditCommunity` schemas in `partials/components.yaml`.
- Updated the `$ref` in `lemmy_spec.yaml` from `RegistrationApplicationView` to `RegistrationApplicationResponse`.
- Added a new schema `RegistrationApplicationResponse` in `lemmy_spec.yaml`.
- No changes in `lemmy-js-client`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->