### PR TITLE
Update version to 0.19.4

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Unofficial Lemmy OpenAPI Documentation
-  version: v0.19.3
+  version: v0.19.4
   license:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html#license-text

--- a/partials/components.yaml
+++ b/partials/components.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Unofficial Lemmy Documentation
-  version: v0.19.3
+  version: v0.19.4
   x-id: partials/components.yaml
   x-comment: >-
     Generated from partials/auto_gen_types.ts by core-types-json-schema


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the Unofficial Lemmy OpenAPI Documentation and Lemmy Documentation to v0.19.4. The x-comment field is added to `partials/components.yaml`.

### Detailed summary
- Updated version to v0.19.4 in `lemmy_spec.yaml` and `partials/components.yaml`
- Added x-comment field in `partials/components.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->