### PR TITLE
Add operation id for listAllMedia endpoint

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1598,6 +1598,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ListMedia'
+      operationId: listAllMedia
       responses:
         '200':
           description: OK

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1659,6 +1659,7 @@ paths:
           application/json:
             schema:
               $ref: 'components.yaml#/components/schemas/ListMedia'
+      operationId: listAllMedia
       responses:
         200:
           description: OK


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `lemmy_spec.yaml` and `partials/api_routes.yaml` files to change the `$ref` value and add an `operationId` field for the `listAllMedia` operation.

### Detailed summary
- Updated `$ref` value in `lemmy_spec.yaml`
- Added `operationId: listAllMedia` in both `lemmy_spec.yaml` and `partials/api_routes.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->