### PR TITLE
Add operationIds, bump to 0.19.5

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Unofficial Lemmy OpenAPI Documentation
-  version: v0.19.4
+  version: v0.19.5
   license:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html#license-text
@@ -1140,6 +1140,7 @@ paths:
     post:
       tags:
         - User
+      operationId: resetPassword
       requestBody:
         content:
           application/json:
@@ -1153,6 +1154,7 @@ paths:
     post:
       tags:
         - User
+      operationId: changePasswordAfterReset
       requestBody:
         content:
           application/json:
@@ -1192,6 +1194,7 @@ paths:
     put:
       tags:
         - User
+      operationId: changePassword
       requestBody:
         content:
           application/json:

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: Unofficial Lemmy OpenAPI Documentation
-  version: v0.19.4
+  version: v0.19.5
   license:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html#license-text
@@ -1194,6 +1194,7 @@ paths:
     post:
       tags:
         - User
+      operationId: resetPassword
       requestBody:
         content:
           application/json:
@@ -1207,6 +1208,7 @@ paths:
     post:
       tags:
         - User
+      operationId: changePasswordAfterReset
       requestBody:
         content:
           application/json:
@@ -1246,6 +1248,7 @@ paths:
     put:
       tags:
         - User
+      operationId: changePassword
       requestBody:
         content:
           application/json:

--- a/partials/components.yaml
+++ b/partials/components.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Unofficial Lemmy Documentation
-  version: v0.19.4
+  version: ignored
   x-id: partials/components.yaml
   x-comment: >-
     Generated from partials/auto_gen_types.ts by core-types-json-schema

--- a/src/gen_components.ts
+++ b/src/gen_components.ts
@@ -9,7 +9,7 @@ const reader = getTypeScriptReaderV2({unsupported: "warn"});
 const writer = getOpenApiWriter({
         format: 'yaml',
         title: 'Unofficial Lemmy Documentation',
-        version: 'v0.19.4',
+        version: 'ignored',
         schemaVersion: "3.0.3"
     },
 )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The PR updates Lemmy documentation versions, adds operation IDs for user endpoints, and upgrades the Lemmy OpenAPI documentation to v0.19.5.

### Detailed summary
- Updated Lemmy documentation versions to 'ignored' and 'v0.19.5'
- Added operation IDs for user endpoints
- Upgraded Lemmy OpenAPI documentation to v0.19.5

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->