### PR TITLE
Add manual deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,7 @@ on:
       - lemmy_spec.yaml
     branches:
       - master
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the GitHub Actions workflow configuration for the `gh-pages` branch, introducing a manual trigger option for the workflow.

### Detailed summary
- Added `workflow_dispatch:` to allow manual triggering of the workflow.
- Maintained the `branches` specification for `master`.
- Confirmed `permissions` for `contents` set to `write`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->