### PR TITLE
Added changes from 0.19.11

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Unofficial Lemmy OpenAPI Documentation
-  version: v0.19.6
+  version: v0.19.11
   license:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html#license-text
@@ -1265,6 +1265,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetSiteResponse'
       summary: Leave the Site admins.
+  /user/donation_dialog_shown:
+    post:
+      tags:
+        - User
+      operationId: donation_dialog_shown
+      responses:
+        '200':
+          description: Ok
+      summary: Mark donation dialog as shown.
   /admin/add:
     post:
       tags:
@@ -2210,6 +2219,9 @@ components:
         collapse_bot_comments:
           title: LocalUser.collapse_bot_comments
           type: boolean
+        last_donation_notification:
+          title: LocalUser.last_donation_notification
+          type: string
       required:
         - id
         - person_id
@@ -2235,6 +2247,7 @@ components:
         - enable_keyboard_navigation
         - enable_animated_images
         - collapse_bot_comments
+        - last_donation_notification
       additionalProperties: false
       title: LocalUser
       type: object

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1324,7 +1324,7 @@ paths:
     post:
       tags:
         - User
-      operationId: donation_dialog_shown
+      operationId: donationDialogShown
       responses:
         200:
           description: Ok

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   title: Unofficial Lemmy OpenAPI Documentation
-  version: v0.19.6
+  version: v0.19.11
   license:
     name: AGPLv3
     url: https://www.gnu.org/licenses/agpl-3.0.en.html#license-text
@@ -1320,6 +1320,15 @@ paths:
               schema:
                 $ref: 'components.yaml#/components/schemas/GetSiteResponse'
       summary: Leave the Site admins.
+  /user/donation_dialog_shown:
+    post:
+      tags:
+        - User
+      operationId: donation_dialog_shown
+      responses:
+        200:
+          description: Ok
+      summary: Mark donation dialog as shown.
   /admin/add:
     post:
       tags:

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -1324,7 +1324,7 @@ paths:
     post:
       tags:
         - User
-      operationId: donationDialogShown
+      operationId: markDonationDialogShown
       responses:
         200:
           description: Ok

--- a/partials/auto_gen_types.ts
+++ b/partials/auto_gen_types.ts
@@ -1375,6 +1375,7 @@ export interface LocalUser {
   enable_keyboard_navigation: boolean;
   enable_animated_images: boolean;
   collapse_bot_comments: boolean;
+  last_donation_notification: string;
 }
 
 

--- a/partials/components.yaml
+++ b/partials/components.yaml
@@ -5114,6 +5114,9 @@ components:
         collapse_bot_comments:
           title: LocalUser.collapse_bot_comments
           type: boolean
+        last_donation_notification:
+          title: LocalUser.last_donation_notification
+          type: string
       required:
         - id
         - person_id
@@ -5139,6 +5142,7 @@ components:
         - enable_keyboard_navigation
         - enable_animated_images
         - collapse_bot_comments
+        - last_donation_notification
       additionalProperties: false
       title: LocalUser
       type: object


### PR DESCRIPTION
Added changes from 0.19.11:

- /user/donation_dialog_shown POST endpoint
- last_donation_notification field in LocalUser

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `lemmy-js-client` by adding a new property `last_donation_notification` to various schemas and introducing a new API endpoint to mark the donation dialog as shown.

### Detailed summary
- Added `last_donation_notification: string;` to `partials/auto_gen_types.ts`.
- Updated `components.yaml` to include `last_donation_notification`.
- Updated API version in `partials/api_routes.yaml` and `lemmy_spec.yaml` from `v0.19.6` to `v0.19.11`.
- Introduced a new POST endpoint `/user/donation_dialog_shown` in both API route files.
- Updated component schemas to include `last_donation_notification`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->