### PR TITLE
Fix missing generated spec

### DIFF
--- a/lemmy_spec.yaml
+++ b/lemmy_spec.yaml
@@ -41,8 +41,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateSite'
       responses:
-        '201':
-          description: Created
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -144,8 +144,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateCommunity'
       responses:
-        '201':
-          description: CREATED
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -226,7 +226,7 @@ paths:
             schema:
               $ref: '#/components/schemas/BlockCommunity'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -377,8 +377,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CreatePost'
       responses:
-        '201':
-          description: Created
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -412,7 +412,7 @@ paths:
             schema:
               $ref: '#/components/schemas/DeletePost'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -429,7 +429,7 @@ paths:
             schema:
               $ref: '#/components/schemas/RemovePost'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -459,7 +459,7 @@ paths:
             schema:
               $ref: '#/components/schemas/LockPost'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -476,7 +476,7 @@ paths:
             schema:
               $ref: '#/components/schemas/FeaturePost'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -493,7 +493,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreatePostLike'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -527,7 +527,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreatePostReport'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -732,7 +732,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateCommentLike'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -766,7 +766,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateCommentReport'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -833,7 +833,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreatePrivateMessage'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -867,7 +867,7 @@ paths:
             schema:
               $ref: '#/components/schemas/DeletePrivateMessage'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -884,7 +884,7 @@ paths:
             schema:
               $ref: '#/components/schemas/MarkPrivateMessageAsRead'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -901,7 +901,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreatePrivateMessageReport'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -971,8 +971,8 @@ paths:
             schema:
               $ref: '#/components/schemas/Register'
       responses:
-        '201':
-          description: CREATED
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -1025,7 +1025,7 @@ paths:
             schema:
               $ref: '#/components/schemas/MarkPersonMentionAsRead'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -1061,7 +1061,7 @@ paths:
             schema:
               $ref: '#/components/schemas/BanPerson'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -1093,7 +1093,7 @@ paths:
             schema:
               $ref: '#/components/schemas/BlockPerson'
       responses:
-        '201':
+        '200':
           description: OK
           content:
             application/json:
@@ -1110,8 +1110,8 @@ paths:
             schema:
               $ref: '#/components/schemas/Login'
       responses:
-        '201':
-          description: CREATED
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -1170,8 +1170,8 @@ paths:
         - User
       operationId: markAllAsRead
       responses:
-        '201':
-          description: CREATED
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -1269,7 +1269,7 @@ paths:
     post:
       tags:
         - User
-      operationId: donation_dialog_shown
+      operationId: markDonationDialogShown
       responses:
         '200':
           description: Ok
@@ -1296,8 +1296,8 @@ paths:
       tags:
         - Admin
       responses:
-        '201':
-          description: CREATED
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -1314,8 +1314,8 @@ paths:
           schema:
             $ref: '#/components/schemas/ListRegistrationApplications'
       responses:
-        '201':
-          description: CREATED
+        '200':
+          description: OK
           content:
             application/json:
               schema:
@@ -1416,8 +1416,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateCustomEmoji'
       responses:
-        '201':
-          description: Created
+        '200':
+          description: OK
           content:
             application/json:
               schema:

--- a/partials/api_routes.yaml
+++ b/partials/api_routes.yaml
@@ -84,8 +84,8 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreateSite'
       responses:
-        "201":
-          description: Created
+        "200":
+          description: OK
           content:
             application/json:
               schema:
@@ -189,8 +189,8 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreateCommunity'
       responses:
-        "201":
-          description: CREATED
+        "200":
+          description: OK
           content:
             application/json:
               schema:
@@ -271,7 +271,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/BlockCommunity'
       responses:
-        "201":
+        "200":
           description: OK
           content:
             application/json:
@@ -424,8 +424,8 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreatePost'
       responses:
-        201:
-          description: Created
+        200:
+          description: OK
           content:
             application/json:
               schema:
@@ -459,7 +459,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/DeletePost'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -476,7 +476,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/RemovePost'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -506,7 +506,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/LockPost'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -523,7 +523,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/FeaturePost'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -541,7 +541,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreatePostLike'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -575,7 +575,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreatePostReport'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -782,7 +782,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreateCommentLike'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -816,7 +816,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreateCommentReport'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -885,7 +885,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreatePrivateMessage'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -919,7 +919,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/DeletePrivateMessage'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -936,7 +936,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/MarkPrivateMessageAsRead'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -953,7 +953,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreatePrivateMessageReport'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -1023,8 +1023,8 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/Register'
       responses:
-        201:
-          description: CREATED
+        200:
+          description: OK
           content:
             application/json:
               schema:
@@ -1079,7 +1079,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/MarkPersonMentionAsRead'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -1115,7 +1115,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/BanPerson'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -1147,7 +1147,7 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/BlockPerson'
       responses:
-        201:
+        200:
           description: OK
           content:
             application/json:
@@ -1164,8 +1164,8 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/Login'
       responses:
-        201:
-          description: CREATED
+        200:
+          description: OK
           content:
             application/json:
               schema:
@@ -1224,8 +1224,8 @@ paths:
         - User
       operationId: markAllAsRead
       responses:
-        201:
-          description: CREATED
+        200:
+          description: OK
           content:
             application/json:
               schema:
@@ -1351,8 +1351,8 @@ paths:
       tags:
         - Admin
       responses:
-        201:
-          description: CREATED
+        200:
+          description: OK
           content:
             application/json:
               schema:
@@ -1369,8 +1369,8 @@ paths:
           schema:
             $ref: 'components.yaml#/components/schemas/ListRegistrationApplications'
       responses:
-        201:
-          description: CREATED
+        200:
+          description: OK
           content:
             application/json:
               schema:
@@ -1471,8 +1471,8 @@ paths:
             schema:
               $ref: 'components.yaml#/components/schemas/CreateCustomEmoji'
       responses:
-        201:
-          description: Created
+        200:
+          description: OK
           content:
             application/json:
               schema:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the HTTP response status codes in the API documentation from `201` (Created) to `200` (OK) across various schemas in the `lemmy_spec.yaml` and `partials/api_routes.yaml` files.

### Detailed summary
- Changed response status from `201` to `200` for:
  - `CreateSite`
  - `CreateCommunity`
  - `BlockCommunity`
  - `CreatePost`
  - `DeletePost`
  - `RemovePost`
  - `LockPost`
  - `FeaturePost`
  - `CreatePostLike`
  - `CreatePostReport`
  - `CreateCommentLike`
  - `CreateCommentReport`
  - `CreatePrivateMessage`
  - `DeletePrivateMessage`
  - `MarkPrivateMessageAsRead`
  - `CreatePrivateMessageReport`
  - `Register`
  - `MarkPersonMentionAsRead`
  - `BanPerson`
  - `BlockPerson`
  - `Login`
  - `markAllAsRead`
  - `donation_dialog_shown` (renamed to `markDonationDialogShown`)
  - `ListRegistrationApplications`
  - `CreateCustomEmoji`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->